### PR TITLE
fixed setElementText for QRCodes (website and text tested)

### DIFF
--- a/dymo.connect.framework.full.js
+++ b/dymo.connect.framework.full.js
@@ -35148,14 +35148,14 @@ dymo.label.framework.Label.prototype._setAddressObjectText = function(objectElem
     @return {dymo.label.framework.Label}
 */
 dymo.label.framework.Label.prototype._setQRCodeObjectText = function(objectElem, text) {
-    if (this.isDCDLabel()) {
-        var dataElem = dymo.xml.getElement(objectElem, "Data");
-        if (dataElem) {
-            var dataStringElem = dymo.xml.getElement(dataElem, "DataString");
-            dymo.xml.setElementText(dataStringElem, text);
-        }
-    }
-    return this;
+  if (this.isDCDLabel()) {
+      let dataElem = dymo.xml.getElement(objectElem, "WebAddressDataHolder");
+      if (dataElem) {
+          let dataStringElem = dymo.xml.getElement(dataElem, "DataString");
+          dymo.xml.setElementText(dataStringElem, text);
+      }
+  }
+  return this;
 }
 
 /** sets content for an Barcode object


### PR DESCRIPTION
This fixes the issue with setting the data for a QRCode via call to "setObjectText".

I tested this with "Website" and "Text" selected for the QRCode in "DYMO Connect for Desktop Windows v1.4.9".